### PR TITLE
CON-390 Update all audit stack new version cloudcoreojsrunner.

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -58,7 +58,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-sns" do
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
-                   :version => "1.8.6"
+                   :version => "*"
                },
                {
                    :name => "js-yaml",
@@ -67,6 +67,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-sns" do
            ])
   json_input '{ "composite name":"PLAN::stack_name",
                 "plan name":"PLAN::name",
+                "cloud account name": "PLAN::cloud_account_name",
                 "violations": COMPOSITE::coreo_aws_rule_runner.advise-sns.report}'
   function <<-EOH
 
@@ -110,17 +111,18 @@ const ALLOW_EMPTY = "${AUDIT_AWS_SNS_ALLOW_EMPTY}";
 const SEND_ON = "${AUDIT_AWS_SNS_SEND_ON}";
 const SHOWN_NOT_SORTED_VIOLATIONS_COUNTER = false;
 
-const VARIABLES = { NO_OWNER_EMAIL, OWNER_TAG, 
+const SETTINGS = { NO_OWNER_EMAIL, OWNER_TAG, 
     ALLOW_EMPTY, SEND_ON, SHOWN_NOT_SORTED_VIOLATIONS_COUNTER};
 
 const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
-const AuditSNS = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
-const notifiers = AuditSNS.getNotifiers();
+const AuditSNS = new CloudCoreoJSRunner(JSON_INPUT, SETTINGS);
+const letters = AuditSNS.getLetters();
 
-const JSONReportAfterGeneratingSuppression = AuditSNS.getSortedJSONForHTMLReports();
-coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
+const newJSONInput = AuditSNS.getSortedJSONForAuditPanel();
+coreoExport('JSONReport', JSON.stringify(newJSONInput));
+coreoExport('report', JSON.stringify(newJSONInput));
 
-callback(notifiers);
+callback(letters);
   EOH
 end
 
@@ -128,6 +130,7 @@ coreo_uni_util_variables "sns-update-planwide-3" do
   action :set
   variables([
                 {'COMPOSITE::coreo_uni_util_variables.sns-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-sns.JSONReport'},
+                {'COMPOSITE::coreo_aws_rule_runner.advise-sns.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-sns.report'},
                 {'COMPOSITE::coreo_uni_util_variables.sns-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-sns.table'}
             ])
 end

--- a/services/config.rb
+++ b/services/config.rb
@@ -120,7 +120,7 @@ const letters = AuditSNS.getLetters();
 
 const newJSONInput = AuditSNS.getSortedJSONForAuditPanel();
 coreoExport('JSONReport', JSON.stringify(newJSONInput));
-coreoExport('report', JSON.stringify(newJSONInput));
+coreoExport('report', JSON.stringify(newJSONInput['violations']));
 
 callback(letters);
   EOH


### PR DESCRIPTION
PLA-3163 Engine does not support empty rules array
CON-287 Audit reports in WebUI and email don't list which AWS account being run on
CON-318 display meta_ attributes on cards
CON-334 add notifiers and jsrunner structures to the AWS config composite
CON-376 Report Emails: Update '# Resources' on cards to '# Cloud Objects'

Please note that this engine fix (https://bitbucket.org/cloudcoreo/engine/pull-requests/471) was merged only to master branch. If you run audit composites on the engine's dev branch it will give you the following error: "There's no rule named '' defined". So I guess we need to merge this fix to dev branch also. In master branch audit composites run correctly.